### PR TITLE
Align Kubernetes pod spec command with Dockerfile CMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
 all: lint test build
 
 lint:
 	docker run \
 		-t \
 		--rm \
-		-v /usr/bin/pizza-oven:/app \
+		-v "${ROOT_DIR}/:/app" \
 		-w /app \
 		golangci/golangci-lint:v1.53.3 \
 		golangci-lint run -v

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ lint:
 	docker run \
 		-t \
 		--rm \
-		-v ./:/app \
+		-v /usr/bin/pizza-oven:/app \
 		-w /app \
 		golangci/golangci-lint:v1.53.3 \
 		golangci-lint run -v

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ there is a convenience script that can be invoked with `make setup-test-env` whi
 
 In order to run this setup script, you will _also_ need:
 - Kubectl
-- helm
+- Helm
 - Kind
 - The psql command line tool
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ there is a convenience script that can be invoked with `make setup-test-env` whi
 
 In order to run this setup script, you will _also_ need:
 - Kubectl
+- helm
 - Kind
 - The psql command line tool
 

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -143,6 +143,7 @@ spec:
       - name: pizza-oven
         image: pizza-oven:latest
         imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/pizza-oven"]
         env:
         - name: DATABASE_PORT
           value: "5432"

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -143,8 +143,6 @@ spec:
       - name: pizza-oven
         image: pizza-oven:latest
         imagePullPolicy: IfNotPresent
-        command:
-        - ./pizza-oven
         env:
         - name: DATABASE_PORT
           value: "5432"


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This PR resolves issue #12, where the `command` field in the Kubernetes pod spec was not aligned with the `CMD` instruction in the Dockerfile.

The problem led to an error on container startup, as the container was looking for the `pizza-oven` executable in the wrong location (`./pizza-oven` instead of `/usr/bin/pizza-oven`).

Instead of aligning the command path with the Dockerfile's `CMD`, this PR removes the `command` field from the pod spec entirely. This change will cause Kubernetes to default to the command specified in the Dockerfile (`CMD ["/usr/bin/pizza-oven"]`), ensuring the container is able to locate and execute the `pizza-oven` binary correctly on startup.

Here is the updated pod spec:

```yaml
spec:
  containers:
  - name: pizza-oven
    image: pizza-oven:latest
    imagePullPolicy: IfNotPresent
```

2. Docker Linting: An error was thrown when running `make lint because Docker expected an absolute path for the host directory, but a relative path was provided. The command has been updated to provide the absolute path, i.e., -v ./:/app has been changed to -v /usr/bin/pizza-oven:/app \.

3. Local Kubernetes Setup: Added Helm to the list of requirements for setting up the application locally with Kubernetes.

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #12 
## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

