### PR TITLE
GitHub actions: fixes broken actions workflows and adds PR tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,17 +1,52 @@
-name: Test and build
+name: Lint, test, and build
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  # So golangci-lint can read the contents of the lint yaml file
+  contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version: 1.20.x
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.53
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version: 1.20.x
+      - name: Test
+        run: make test
+
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: 1.20
-      - name: Build
-        run: go build -v ./...
-      - name: Test
-        run: go test -v ./...
+          go-version: 1.20.x
+      - name: Build go binary
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# This is where the "make local" target drops build artifacts
+build/
+
+# explicitly ignore env files to ensure secrets aren't being accidentally committed
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all lint test run local build setup-test-env teardown-test-env
+
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 all: lint test build
@@ -16,6 +18,9 @@ test:
 
 run:
 	go run main.go
+
+local:
+	go build -o build/pizza-oven main.go
 
 build:
 	docker build . -t pizza-oven:latest


### PR DESCRIPTION
## Description

This PR does a few things:
- Fixes go tests in CI. Weirdly, there was an issue with how the `1.20` tag was getting used in the setup-go action. https://github.com/actions/setup-go/issues/326
  Setting this verbosely to `1.20.x` should fix this.
- Adds linting via the golangci-lint action
- Parallelizes the actions
- Adds a `.gitignore`
- Adds a `make local` target for building the go binary locally into a local `build/` directory
- Ensure the makefile targets are all set to phony

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #6

## Mobile & Desktop Screenshots/Recordings

N/a

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

N/a

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/NWlBEcDW5evFS/giphy.gif)
