### PR TITLE
fix: Use base image that includes CA certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile:1.4
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.0 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
@@ -15,6 +15,6 @@ RUN --mount=target=/go/pkg/mod,type=cache \
     --mount=target=/root/.cache,type=cache \
     xx-go build -ldflags="${GO_LDFLAGS}" -o pizza-oven .
 
-FROM scratch
+FROM golang:alpine
 COPY --from=builder /app/pizza-oven /usr/bin/
 CMD ["/usr/bin/pizza-oven"]


### PR DESCRIPTION
## Description

Ran into issues where the pizza image could not make requests to GitHub due to TLS errors:

```
{"level":"info","ts":1692036899.686633,"caller":"app/main.go:38","msg":"initiated zap logger with level: 0"}
{"level":"warn","ts":1692036899.6869462,"caller":"app/main.go:43","msg":"Failed to load the dot env file. Continuing with existing environment: open .env: no such file or directory"}
{"level":"info","ts":1692036900.023071,"caller":"app/main.go:65","msg":"Initiating cache git provider"}
{"level":"info","ts":1692036900.0319865,"caller":"server/server.go:44","msg":"Starting server on port 8080"}
{"level":"error","ts":1692036923.6407166,"caller":"server/server.go:82","msg":"Could not process repository input: &{0x400000ce70 <nil> <nil> false true {0 0} true true false 0x2970b0} with error: could not put to the git repo LRU cache: could not clone into cache directory: Get \"https://github.com/jpmcb/gopherlogs/info/refs?service=git-upload-pack\": tls: failed to verify certificate: x509: certificate signed by unknown authority","stacktrace":"github.com/open-sauced/pizza/oven/pkg/server.PizzaOvenServer.handleRequest.func1\n\t/app/pkg/server/server.go:82"}
2023/08/14 18:15:23 http: superfluous response.WriteHeader call from github.com/open-sauced/pizza/oven/pkg/server.PizzaOvenServer.handleRequest.func1 (server.go:83)
```

Notice the errors on not being able to verity the server's cerrs due to "unknown authority"

TLDR: we need a base image that has well known CAs. We can't just use a scratch image and I don't want to be in the business of managing and loading our own CAs for the pizza oven service.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

N/a - related to production usage.

## Mobile & Desktop Screenshots/Recordings

N/a

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Will need to do another release and get this in prod / dev environments to validate fully but after building locally, this now works so I have high confidence this is the fix.

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
