### PR TITLE
feat: Normalizes and validates git URLs before accepting for processing

### DIFF
--- a/pkg/common/validation.go
+++ b/pkg/common/validation.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+// IsValidGitRepo returns true if the provided git repo URL is a valid and reachable
+// git repository. This is equivalent to running "git ls-remote" on the provided
+// URL string. This may result in some unexpected "authentication required" or
+// "repository not found" errors which is standard for git to return in these
+// situations.
+func IsValidGitRepo(repoURL string) (bool, error) {
+	remoteConfig := &config.RemoteConfig{
+		Name: "source",
+		URLs: []string{
+			repoURL,
+		},
+	}
+
+	remote := git.NewRemote(memory.NewStorage(), remoteConfig)
+
+	_, err := remote.List(&git.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("could not list remote repository: %s", err.Error())
+	}
+
+	return true, nil
+}
+
+// NormalizeGitURL attempts to take a raw git repo URL and ensure it is normalized
+// before being validated or entered into the database
+func NormalizeGitURL(repoURL string) (string, error) {
+	parsedURL, err := url.Parse(repoURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if it has a valid protocol specified (e.g., https, ssh, git)
+	if parsedURL.Scheme != "git" && parsedURL.Scheme != "https" && parsedURL.Scheme != "file" {
+		return "", fmt.Errorf("repo URL missing valid protocol scheme (https, git, file): %s", repoURL)
+	}
+
+	// Trim trailing slashes
+	// Example: https://github.com/open-sauced/pizza/ to https://github.com/open-sauced/pizza
+	trimmedPath := strings.TrimSuffix(parsedURL.Path, "/")
+
+	// Remove .git suffix if present
+	// Example: https://github.com/open-sauced/pizza.git to https://github.com/open-sauced/pizza
+	trimmedPath = strings.TrimSuffix(trimmedPath, ".git")
+
+	parsedURL.Path = trimmedPath
+
+	return parsedURL.String(), nil
+}

--- a/pkg/common/validation_test.go
+++ b/pkg/common/validation_test.go
@@ -1,0 +1,73 @@
+package common
+
+import "testing"
+
+func TestNormalizeGitURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Fully normalizes",
+			url:      "https://github.com/user/repo.git/",
+			expected: "https://github.com/user/repo",
+		},
+		{
+			name:     "Removes trailing .git",
+			url:      "https://github.com/user/repo.git",
+			expected: "https://github.com/user/repo",
+		},
+		{
+			name:     "Removes trailing slash",
+			url:      "https://github.com/user/repo/",
+			expected: "https://github.com/user/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizedURL, err := NormalizeGitURL(tt.url)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			if normalizedURL != tt.expected {
+				t.Fatalf("normalized URL: %s is not expected: %s", normalizedURL, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeGitURLError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "Missing protocol fails",
+			url:  "github.com/user/repo",
+		},
+		{
+			name: "Malformed protocol fails",
+			url:  "ht:/github.com/user/repo",
+		},
+		{
+			name: "Unusable protocol fails",
+			url:  "ssh://github.com/user/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizedURL, err := NormalizeGitURL(tt.url)
+			if err == nil {
+				t.Fatalf("expected error, got none: %s", normalizedURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This patch is twofold:
1. Incoming request URLs to the bake route will be normalized. This way, we prevent duplicate entries from dropping in (like with `https://github.com/open-sauced/pizza/` and `https://github.com/open-sauced/pizza`
2. Validates that the repo URL is actually a git repo. This is accomplished by essentially calling `git ls-remote` on the provided URL which is more efficient than doing a shallow clone.

I also cleaned up where `repoURL` was getting called in the `processRepository` function

##### Example:

On calling my local repo with:
```sh
❯ pizza bake -e http://localhost:8080 https://github.com/jpmcb/dotfiles/
```

it works and correctly validates/normalizes the url. Here are the debug logs from the server 👍🏼 

```
❯ go run main.go --debug
2023-08-29T14:35:26.033-0600    INFO    pizza/main.go:41        initiated zap logger with level: -1
2023-08-29T14:35:26.091-0600    INFO    pizza/main.go:91        Initiating cache git provider
2023-08-29T14:35:26.091-0600    INFO    server/server.go:52     Starting server on port 8080
2023-08-29T14:35:28.328-0600    DEBUG   server/server.go:78     Validating and normalizing repository URL: https://github.com/jpmcb/dotfiles/
2023-08-29T14:35:28.623-0600    DEBUG   server/server.go:144    Checking if repository is already in database: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.643-0600    DEBUG   server/server.go:158    Getting repo via configured git provider: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.644-0600    DEBUG   providers/cache.go:47   Getting repo from LRU cache: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.644-0600    DEBUG   providers/cache.go:51   Cache miss. Putting to cache: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.644-0600    DEBUG   providers/cache.go:58   Opening and fetching repo: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.749-0600    DEBUG   server/server.go:169    Inspecting the head of the git repo: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.749-0600    DEBUG   server/server.go:175    Getting last commit in DB: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.754-0600    DEBUG   server/server.go:181    Querying commits since: 2022-12-08 22:47:01 +0000 UTC
2023-08-29T14:35:28.754-0600    DEBUG   server/server.go:189    Getting commit iterator with git log options: {1f7099ac02c52ff4b775ac894b2e26ed5a56207e 0 <nil> <nil> false 2022-12-08 22:47:01 +0000 UTC <nil>}
2023-08-29T14:35:28.754-0600    DEBUG   server/server.go:195    Iterating commits in repository: https://github.com/jpmcb/dotfiles
2023-08-29T14:35:28.754-0600    DEBUG   server/server.go:207    Inspecting commit: jpmmcb@amazon.com 1f7099ac02c52ff4b775ac894b2e26ed5a56207e 2022-12-08 22:47:01 +0000 UTC
2023-08-29T14:35:28.757-0600    DEBUG   server/server.go:221    Checking if commit already in database: 1f7099ac02c52ff4b775ac894b2e26ed5a56207e
2023-08-29T14:35:28.760-0600    DEBUG   server/server.go:238    Finished processing: https://github.com/jpmcb/dotfiles
```

In the case that if fails, this should now return the invalid request back down to the client:

```
❯ pizza bake -e http://localhost:8080 github.com/jpmcb/dotfiles
Resp body: Could not normalize provided repo URL: repo URL missing valid protocol scheme (https, git, file): github.com/jpmcb/dotfiles

```

```
❯ pizza bake -e http://localhost:8080 https://github.com/jpmcb/doesntexist
Resp body: Error validating remote git repo URL: could not list remote repository: authentication required
```

(I thought the auth error was maybe a bug in go-git, but interestingly, this is the same behavior as `git ls-remote` and is working as expected).

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes #29 cc @k1nho 

## Mobile & Desktop Screenshots/Recordings

N/a

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/gEvab1ilmJjA82FaSV/giphy.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
